### PR TITLE
Add mimetype='application/javascript' for js files

### DIFF
--- a/html/server.py
+++ b/html/server.py
@@ -177,6 +177,11 @@ def delete_save(save):
 
     return 'done'
 
+@app.route('/<path:filename>.js')
+def serve_js(filename):
+    file_path = f'{filename}.js'
+    return flask.send_from_directory('.', file_path, mimetype='application/javascript')
+
 @app.route('/<path:filename>')
 def static_files(filename):
     return flask.send_from_directory('.', filename)


### PR DESCRIPTION
The MS Edge browser shows:
```
Failed to initialize modules.
Error: TypeError: Failed to fetch dynamically imported module: http://localhost:8880/pzmap/map.js
```
It could be any js files in the directory pzmap.
While the DevTools console window reads:
```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/plain". Strict MIME type checking is enforced for module scripts per HTML spec.
```
This PR is to fix the MIME type for all js files as 'application/javascript'.