### PR TITLE
Add cell_coords on UI for pointermove event

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 pzmap2dzi main.py 1.0.6
-html 1.0.5
+html 1.0.6

--- a/html/pzmap.html
+++ b/html/pzmap.html
@@ -52,6 +52,7 @@
         <button id="marker_btn" onclick="toggleMarkerUI()"></button>
         <button id="trimmer_btn" onclick="toggleTrimmer()"></button>
         <div id="main_output" class="inline">Initialization Failed</div>
+        <div id="cell_coords" class="inline" style="margin-left: 1em;">Cell: (0, 0)</div>
         <div class="text-right">
             <select id="route_selector" onchange="onChangeRoute()"></select>
             <button id="change_view_btn" onclick="onChangeView()"></button>

--- a/html/pzmap.html
+++ b/html/pzmap.html
@@ -52,7 +52,7 @@
         <button id="marker_btn" onclick="toggleMarkerUI()"></button>
         <button id="trimmer_btn" onclick="toggleTrimmer()"></button>
         <div id="main_output" class="inline">Initialization Failed</div>
-        <div id="cell_coords" class="inline" style="margin-left: 1em;">Cell: (0, 0)</div>
+        <div id="coords" class="inline" style="margin-left: 1em;"></div>
         <div class="text-right">
             <select id="route_selector" onchange="onChangeRoute()"></select>
             <button id="change_view_btn" onclick="onChangeView()"></button>

--- a/html/pzmap.js
+++ b/html/pzmap.js
@@ -382,6 +382,13 @@ function initOSD() {
         g.viewer.drawer.context.msImageSmoothingEnabled = false;
         g.viewer.drawer.context.imageSmoothingEnabled = false;
     }
+
+    const cellCoordsElement = document.getElementById('cell_coords');
+
+    document.getElementById('map_div').addEventListener('pointermove', (event) => {
+        const [sx, sy] = c.getSquare(event);
+        cellCoordsElement.textContent = `Cell: (${sx}, ${sy})`;
+    });
 }
 
 function init(callback=null) {

--- a/html/pzmap.js
+++ b/html/pzmap.js
@@ -383,11 +383,9 @@ function initOSD() {
         g.viewer.drawer.context.imageSmoothingEnabled = false;
     }
 
-    const cellCoordsElement = document.getElementById('cell_coords');
-
     document.getElementById('map_div').addEventListener('pointermove', (event) => {
         const [sx, sy] = c.getSquare(event);
-        cellCoordsElement.textContent = `Cell: (${sx}, ${sy})`;
+        util.setOutput('coords', 'black', i18n.T('Coords') + `: (${sx}, ${sy})`);
     });
 }
 

--- a/html/pzmap/coordinates.js
+++ b/html/pzmap/coordinates.js
@@ -135,8 +135,8 @@ export function stepToZoom(step) {
 }
 
 export function getSquare(event) {
-    let x = event.position.x * window.devicePixelRatio;
-    let y = event.position.y * window.devicePixelRatio;
+    let x = event.x * window.devicePixelRatio;
+    let y = event.y * window.devicePixelRatio;
     return getSquareByCanvas(g.viewer, g.base_map, x, y, g.currentLayer);
 }
 

--- a/html/pzmap/i18n/i18n.yaml
+++ b/html/pzmap/i18n/i18n.yaml
@@ -359,6 +359,9 @@ template:
     TrimmerError:
         en: '<b>Trimming failed, error: {error}</b>'
         cn: '<b>裁剪失败，错误: {error}</b>'
+    Coords:
+        en: 'Coordinates'
+        cn: '坐标'        
     RouteSelectorTitle:
         en: 'Change Route'
         cn: '切换路径'


### PR DESCRIPTION
This PR is to add "Cell: (x, y)" on the UI to represent the coordinates of the cell pointed by the mouse.
The cell coordinates are used in Project Zomboid's spawnpoints.lua files.